### PR TITLE
Style questionnaire and results sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -81,3 +81,67 @@ p {
     flex-direction: column;
   }
 }
+#questionnaire-container {
+  margin: 3rem 0;
+}
+
+#options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.option-card {
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.option-card:hover {
+  background-color: #e9ecef;
+}
+
+.option-card.selected {
+  border: 2px solid #007bff;
+  background-color: #f0f8ff;
+}
+
+button {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+button:hover {
+  background-color: #0069d9;
+}
+
+#next-btn {
+  margin-top: 1.5rem;
+}
+
+#results-container textarea {
+  width: 100%;
+  min-height: 200px;
+  padding: 1rem;
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  resize: vertical;
+}
+
+#copy-notification {
+  text-align: center;
+  padding: 0.75rem 1rem;
+  background-color: #28a745;
+  color: #fff;
+  border-radius: 6px;
+  display: none;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add questionnaire container spacing and flex layout for options
- style interactive option cards including hover and selected states
- update button, next button, and results textarea/notification styles for consistent UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05dec8e308326b4289cf156f52dcb