### PR TITLE
Add initial questionnaire display logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,4 +83,60 @@ const appData = {
   }
 };
 
+const questionnaireContainer = document.getElementById('questionnaire-container');
+const resultsContainer = document.getElementById('results-container');
+const questionTitle = document.getElementById('question-title');
+const optionsContainer = document.getElementById('options-container');
+const nextButton = document.getElementById('next-btn');
+
+let currentQuestionIndex = 0;
+let userAnswers = [];
+
+function displayQuestion() {
+  const currentQuestion = appData.questions[currentQuestionIndex];
+
+  if (!currentQuestion) {
+    return;
+  }
+
+  questionTitle.innerText = currentQuestion.title;
+  optionsContainer.innerHTML = '';
+
+  if (currentQuestion.type === 'dropdown') {
+    const selectElement = document.createElement('select');
+
+    currentQuestion.options.forEach((optionText) => {
+      const optionElement = document.createElement('option');
+      optionElement.value = optionText;
+      optionElement.innerText = optionText;
+      selectElement.appendChild(optionElement);
+    });
+
+    optionsContainer.appendChild(selectElement);
+    return;
+  }
+
+  const optionACard = document.createElement('div');
+  optionACard.classList.add('option-card');
+  optionACard.innerText = currentQuestion.optionA;
+
+  const optionBCard = document.createElement('div');
+  optionBCard.classList.add('option-card');
+  optionBCard.innerText = currentQuestion.optionB;
+
+  const optionCards = [optionACard, optionBCard];
+
+  optionCards.forEach((card) => {
+    card.addEventListener('click', () => {
+      optionCards.forEach((otherCard) => otherCard.classList.remove('selected'));
+      card.classList.add('selected');
+    });
+  });
+
+  optionsContainer.appendChild(optionACard);
+  optionsContainer.appendChild(optionBCard);
+}
+
+displayQuestion();
+
 export default appData;


### PR DESCRIPTION
## Summary
- add DOM references for key questionnaire elements
- render questions dynamically including dropdown support
- display the initial question on page load

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d061fde52c8326a391760901d7cf7e